### PR TITLE
Upstream codereview changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+/composer.lock

--- a/htmxpress.php
+++ b/htmxpress.php
@@ -4,7 +4,7 @@
  * Plugin Name:  HTMXpress
  * Plugin URI:   https://vandragt.com
  * Description:  HTMX for WordPress
- * Version:      0.1
+ * Version:      0.1.1
  * Author:       Sander van Dragt <sander@vandragt.com>
  * Author URI:   https://vandragt.com
  * License:      GPL3

--- a/htmxpress.php
+++ b/htmxpress.php
@@ -1,16 +1,17 @@
-<?php
-/*
-Plugin Name:  HTMXpress
-Plugin URI:   https://vandragt.com
-Description:  HTMX for WordPress
-Version:      0.1
-Author:       Sander van Dragt <sander@vandragt.com>
-Author URI:   https://vandragt.com
-License:      GPL2
-License URI:  https://www.gnu.org/licenses/gpl-2.0.html
-Text Domain:  htmxpress
-Domain Path:  /languages
-*/
+<?php //phpcs:ignore PSR1.Files.SideEffects.FoundWithSymbols
+
+/**
+ * Plugin Name:  HTMXpress
+ * Plugin URI:   https://vandragt.com
+ * Description:  HTMX for WordPress
+ * Version:      0.1
+ * Author:       Sander van Dragt <sander@vandragt.com>
+ * Author URI:   https://vandragt.com
+ * License:      GPL2
+ * License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:  htmxpress
+ * Domain Path:  /languages
+ */
 
 namespace HtmxPress;
 
@@ -18,20 +19,35 @@ require_once( __DIR__ . '/inc/assets.php' );
 require_once( __DIR__ . '/inc/endpoint.php' );
 require_once( __DIR__ . '/inc/template.php' );
 
-function activate() {
+/**
+ * Activate the plugin.
+ *
+ * @return void
+ */
+function activate() : void {
 	Endpoint\register();
 	flush_rewrite_rules();
 }
 
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\activate' );
 
-function deactivate() {
+/**
+ * Deactivate the plugin.
+ *
+ * @return void
+ */
+function deactivate() : void {
 	flush_rewrite_rules();
 }
 
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\deactivate' );
 
-function bootstrap() {
+/**
+ * Bootstrap the plugin.
+ *
+ * @return void
+ */
+function bootstrap() : void {
 	Endpoint\register();
 	Template\bootstrap();
 	Assets\bootstrap();

--- a/htmxpress.php
+++ b/htmxpress.php
@@ -15,21 +15,12 @@
 
 namespace HtmxPress;
 
+const OPTION_REWRITE_RULES = 'htmxpress_rewrite_rules';
+const OPTION_REWRITE_RULES_VERSION = '20250604';
+
 require_once( __DIR__ . '/inc/assets.php' );
 require_once( __DIR__ . '/inc/endpoint.php' );
 require_once( __DIR__ . '/inc/template.php' );
-
-/**
- * Activate the plugin.
- *
- * @return void
- */
-function activate() : void {
-	Endpoint\register();
-	flush_rewrite_rules();
-}
-
-register_activation_hook( __FILE__, __NAMESPACE__ . '\\activate' );
 
 /**
  * Deactivate the plugin.
@@ -37,6 +28,7 @@ register_activation_hook( __FILE__, __NAMESPACE__ . '\\activate' );
  * @return void
  */
 function deactivate() : void {
+	delete_option( OPTION_REWRITE_RULES );
 	flush_rewrite_rules();
 }
 
@@ -49,6 +41,10 @@ register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\deactivate' );
  */
 function bootstrap() : void {
 	Endpoint\register();
+	if ( update_option( OPTION_REWRITE_RULES, OPTION_REWRITE_RULES_VERSION ) ) {
+		flush_rewrite_rules();
+	}
+
 	Template\bootstrap();
 	Assets\bootstrap();
 }

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -17,8 +17,8 @@ function register() {
 function add_post_nonce() {
 	// PHP sees this as 'HTTP_X_WP_NONCE' in _SERVER.
 	$nonce = wp_create_nonce( 'htmx' );
-	$data = "window.onload = function() {document.body.addEventListener('htmx:configRequest', (event) => {
-        event.detail.headers['X-WP-Nonce'] = '$nonce';
-      })}";
+	$data = 'window.onload = function() {document.body.addEventListener("htmx:configRequest", (event) => {
+        event.detail.headers["X-WP-Nonce"] = ' . wp_json_encode( $nonce ) . ';
+      })}';
 	wp_add_inline_script( 'htmx', $data );
 }

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -10,6 +10,7 @@ function register() {
 	// CDN use for prototyping only
 	wp_enqueue_script( 'htmx', 'https://unpkg.com/htmx.org@1.9.3' );
 
+	wp_enqueue_script( 'htmx', 'https://unpkg.com/htmx.org@1.9.10', [], null, [ 'strategy' => 'defer'] );
 	add_post_nonce();
 }
 

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -1,20 +1,36 @@
 <?php
+/**
+ * Asset registration and noncing.
+ */
 
 namespace HtmxPress\Assets;
 
-function bootstrap() {
+/**
+ * Bootstrap the asset registration.
+ *
+ * @return void
+ */
+function bootstrap() : void {
 	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\register' );
 }
 
-function register() {
-	// CDN use for prototyping only
-	wp_enqueue_script( 'htmx', 'https://unpkg.com/htmx.org@1.9.3' );
-
+/**
+ * Register the htmx script.
+ *
+ * @return void
+ */
+function register() : void {
+	// CDN use for prototyping only.
 	wp_enqueue_script( 'htmx', 'https://unpkg.com/htmx.org@1.9.10', [], null, [ 'strategy' => 'defer'] );
 	add_post_nonce();
 }
 
-function add_post_nonce() {
+/**
+ * Inline script to add a nonce to pages.
+ *
+ * @return void
+ */
+function add_post_nonce() : void {
 	// PHP sees this as 'HTTP_X_WP_NONCE' in _SERVER.
 	$nonce = wp_create_nonce( 'htmx' );
 	$data = 'window.onload = function() {document.body.addEventListener("htmx:configRequest", (event) => {

--- a/inc/endpoint.php
+++ b/inc/endpoint.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Register endpoints.
+ */
 
 namespace HtmxPress\Endpoint;
 
 const HTMX_ENDPOINT = 'htmx';
 
+/**
+ * Register HTMX templates endpoint.
+ *
+ * @return void
+ */
 function register() : void {
 	// creates /htmx and htmx query var
 	add_rewrite_endpoint( HTMX_ENDPOINT, EP_ROOT );

--- a/inc/template.php
+++ b/inc/template.php
@@ -28,7 +28,7 @@ function render() : void {
 	}
 
 	// POST nonce protection
-	if ( $_SERVER["REQUEST_METHOD"] === 'POST' && ! is_nonced() ) {
+	if ( $_SERVER['REQUEST_METHOD'] === 'POST' && ! is_nonced() ) {
 		return;
 	}
 	$template_name = get_template_name();

--- a/inc/template.php
+++ b/inc/template.php
@@ -1,14 +1,27 @@
 <?php
+/**
+ * Templating functions.
+ */
 
 namespace HtmxPress\Template;
 
 use const HtmxPress\Endpoint\HTMX_ENDPOINT;
 
-function bootstrap() {
+/**
+ * Bootstrap.
+ *
+ * @return void
+ */
+function bootstrap() : void {
 	add_action( 'template_redirect', __NAMESPACE__ . '\\render' );
 }
 
-function render() {
+/**
+ * Render a template.
+ *
+ * @return void
+ */
+function render() : void {
 	global $wp_query;
 	if ( ! isset( $wp_query->query_vars[ HTMX_ENDPOINT ] ) ) {
 		return;
@@ -43,6 +56,11 @@ function is_nonced() : bool {
 	return ! ! wp_verify_nonce( $nonce, 'htmx' );
 }
 
+/**
+ * Get the template name. Defaults to 'root' if no query var is set.
+ *
+ * @return string
+ */
 function get_template_name() : string {
 	$template_name = 'root';
 	$query_var = get_query_var( HTMX_ENDPOINT );

--- a/inc/template.php
+++ b/inc/template.php
@@ -53,7 +53,7 @@ function is_nonced() : bool {
 	}
 
 	// Check the nonce is not false.
-	return ! ! wp_verify_nonce( $nonce, 'htmx' );
+	return (bool) wp_verify_nonce( $nonce, 'htmx' );
 }
 
 /**

--- a/inc/template.php
+++ b/inc/template.php
@@ -32,10 +32,31 @@ function render() : void {
 		return;
 	}
 	$template_name = get_template_name();
-	load_template_or_404( $template_name );
+	$template_loaded = load_htmx_template( $template_name );
+	maybe_set_404( $template_loaded );
 	exit;
 }
 
+/**
+ * Set 404 status if the template wasn't loaded.
+ *
+ * @param bool $template_loaded Whether a template was loaded.
+ *
+ * @return void
+ */
+function maybe_set_404( bool $template_loaded ) : void {
+	global $wp_query;
+	if ( ! $template_loaded ) {
+		$wp_query->set_404();
+		status_header( 404 );
+	}
+}
+
+/**
+ * Check if the request is nonced.
+ *
+ * @return bool
+ */
 function is_nonced() : bool {
 	$nonce = null;
 
@@ -71,35 +92,32 @@ function get_template_name() : string {
 	return $template_name;
 }
 
-function load_template_or_404( string $template_name ) : void {
-	// Allow adding to the template paths, with the included demo ones as a fallback.
+/**
+ * Load a template or return 404 if it's not found. This is a copy of the WordPress `load_template` function, but with
+ * 404 handling.
+ *
+ * @param string $template_name Name of the template to load.
+ *
+ * @return bool Whether a template was loaded
+ */
+function load_htmx_template( string $template_name ) : bool {
+	// Allow adding to the template paths.
+	// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- Established filter.
 	$paths = apply_filters( 'htmx.template_paths', [] );
-	if (empty($paths)) {
-		$paths[] = dirname( __FILE__, 2 ) . "/templates/";
-	}
 	array_walk( $paths, static function ( &$path ) {
 		$path = trailingslashit( $path );
 	} );
 
-	$match = false;
-	// match one path
+	// walk through the paths to find the first matching template.
+	$template_loaded = false;
 	foreach ( $paths as $path ) {
 		$path = "$path${template_name}.php";
 		if ( file_exists( $path ) ) {
-			$match = true;
-			$is_partial = str_starts_with( $template_name, 'partial-' );
-			if ( $is_partial ) {
-				include $path;
-				break;
-			}
+			$template_loaded = true;
 			load_template( $path );
 			break;
 		}
 	}
 
-	global $wp_query;
-	if ( ! $match ) {
-		$wp_query->set_404();
-		status_header( 404 );
-	}
+	return $template_loaded;
 }

--- a/inc/template.php
+++ b/inc/template.php
@@ -61,9 +61,9 @@ function is_nonced() : bool {
 	$nonce = null;
 
 	if ( isset( $_REQUEST['_wpnonce'] ) ) {
-		$nonce = $_REQUEST['_wpnonce'];
+		$nonce = sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) );
 	} elseif ( isset( $_SERVER['HTTP_X_WP_NONCE'] ) ) {
-		$nonce = $_SERVER['HTTP_X_WP_NONCE'];
+		$nonce = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_WP_NONCE'] ) );
 	}
 
 	if ( null === $nonce ) {

--- a/inc/template.php
+++ b/inc/template.php
@@ -28,7 +28,8 @@ function render() : void {
 	}
 
 	// POST nonce protection
-	if ( $_SERVER['REQUEST_METHOD'] === 'POST' && ! is_nonced() ) {
+	$request_method = strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) );
+	if ( $request_method === 'POST' && ! is_nonced() ) {
 		return;
 	}
 	$template_name = get_template_name();

--- a/inc/template.php
+++ b/inc/template.php
@@ -104,6 +104,11 @@ function load_htmx_template( string $template_name ) : bool {
 	// Allow adding to the template paths.
 	// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- Established filter.
 	$paths = apply_filters( 'htmx.template_paths', [] );
+
+	if ( empty( $paths ) ) {
+		// Demo template registration
+		$paths[] = dirname( __FILE__, 2 ) . "/templates/";
+	}
 	array_walk( $paths, static function ( &$path ) {
 		$path = trailingslashit( $path );
 	} );

--- a/inc/template.php
+++ b/inc/template.php
@@ -111,7 +111,7 @@ function load_htmx_template( string $template_name ) : bool {
 	// walk through the paths to find the first matching template.
 	$template_loaded = false;
 	foreach ( $paths as $path ) {
-		$path = "$path${template_name}.php";
+		$path .= $template_name . ".php";
 		if ( file_exists( $path ) ) {
 			$template_loaded = true;
 			load_template( $path );


### PR DESCRIPTION
We've used the plugin on a project and I've upstreamed code review changes.

1. Updated HTMX and deferred loading it.
1. Function documentation improvements
2. return types were added.
3. Sanitization of nonce checking
4. Separation of concerns in the template loading logic, including removal of the "partial" loading of templates, which did not currently bypass the WordPress logic anyway.

- [x] test changes
- [x] test 404
- [x] restore demo template registration regression
- [x] documentation is up to date